### PR TITLE
修复一键启动快捷方式创建与 D3D11 渲染启动

### DIFF
--- a/src/BetterEndfield.UI/MainWindow.xaml.cs
+++ b/src/BetterEndfield.UI/MainWindow.xaml.cs
@@ -468,21 +468,27 @@ public sealed partial class MainWindow : Window
         }
     }
 
-    private async void CreateGameShortcutButton_Click(object sender, RoutedEventArgs e)
+    private void CreateGameShortcutButton_Click(object sender, RoutedEventArgs e)
     {
-        if (!await SaveAsync(showSuccess: false))
+        string mapperPath = MapperPathBox.Text.Trim();
+        string gamePath = GamePathBox.Text.Trim();
+        if (!File.Exists(mapperPath))
         {
+            ShowStatus("注入器路径无效", "请选择有效的 Il2cppDumper.exe。", InfoBarSeverity.Error);
+            return;
+        }
+        if (!File.Exists(gamePath))
+        {
+            ShowStatus("游戏路径无效", "请选择有效的 Endfield.exe。", InfoBarSeverity.Error);
             return;
         }
 
         try
         {
-            string shortcutPath = ShortcutService.CreateGameShortcut(
-                MapperPathBox.Text,
-                GamePathBox.Text);
+            string shortcutPath = ShortcutService.CreateGameShortcut(mapperPath, gamePath);
             ShowStatus(
                 "一键启动快捷方式已创建",
-                $"已保存当前配置并创建：{shortcutPath}",
+                $"已创建：{shortcutPath}",
                 InfoBarSeverity.Success);
         }
         catch (Exception exception) when (

--- a/src/BetterEndfield.UI/Services/ShortcutService.cs
+++ b/src/BetterEndfield.UI/Services/ShortcutService.cs
@@ -54,7 +54,7 @@ internal static class ShortcutService
 
     private static string GetDesktopDirectory()
     {
-        string desktop = Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory);
+        string desktop = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
         if (string.IsNullOrWhiteSpace(desktop))
         {
             throw new DirectoryNotFoundException("无法定位当前用户的桌面目录。");

--- a/tools/IL2CPP-Dumper-src/Mapper/src/main.cxx
+++ b/tools/IL2CPP-Dumper-src/Mapper/src/main.cxx
@@ -82,7 +82,7 @@ static bool LaunchAndInject( const std::string & exePath, const std::vector<BYTE
     strcpy_s( workDir, exePath.c_str( ) );
     PathRemoveFileSpecA( workDir );
 
-    std::string cmdLine = "\"" + exePath + "\"";
+    std::string cmdLine = "\"" + exePath + "\" -force-d3d11";
 
     PROCESS_INFORMATION pi = { 0 };
     STARTUPINFOA        si = { sizeof( STARTUPINFOA ) };


### PR DESCRIPTION
1. `LaunchAndInject` 少了 `-force-d3d11` ，游戏默认以 Vulkan 运行，会在与其它加载器协同时崩溃。
2. `CreateGameShortcutButton_Click` 调用 `SaveAsync` ，导致角色替换配置不完整时，快捷方式静默不创建；现改为只校验注入器路径与游戏路径。
3. 使用 OneDrive 时桌面重定向，`CreateGameShortcutButton_Click` 使用物理桌面 (`SpecialFolder.DesktopDirectory`) 作为快捷方式创建路径会写入到不可见目录，改为使用逻辑桌面 (`SpecialFolder.Desktop`)。